### PR TITLE
Add and derive serialization and deserialization traits (serde)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ name = "xorfilter"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 rand = "0.6.4"

--- a/benches/xor_bench.rs
+++ b/benches/xor_bench.rs
@@ -5,7 +5,6 @@ use xorfilter::Xor8;
 
 use std::collections::hash_map::RandomState;
 
-
 fn bench_populate_keys_100000(c: &mut Criterion) {
     let seed: u128 = random();
     let mut rng = SmallRng::from_seed(seed.to_le_bytes());
@@ -17,11 +16,13 @@ fn bench_populate_keys_100000(c: &mut Criterion) {
         *key = rng.gen();
     }
 
-    c.bench_function("populate_keys_100000",|b| b.iter(|| {
-        let mut filter = Xor8::<RandomState>::new();
-        filter.populate_keys(&keys);
-        filter.build();
-    }));
+    c.bench_function("populate_keys_100000", |b| {
+        b.iter(|| {
+            let mut filter = Xor8::<RandomState>::new();
+            filter.populate_keys(&keys);
+            filter.build();
+        })
+    });
 }
 
 fn bench_build_keys_100000(c: &mut Criterion) {
@@ -35,10 +36,12 @@ fn bench_build_keys_100000(c: &mut Criterion) {
         *key = rng.gen();
     }
 
-    c.bench_function("bench_build_keys_100000",|b| b.iter(|| {
-        let mut filter = Xor8::<RandomState>::new();
-        filter.build_keys(&keys);
-    }));
+    c.bench_function("bench_build_keys_100000", |b| {
+        b.iter(|| {
+            let mut filter = Xor8::<RandomState>::new();
+            filter.build_keys(&keys);
+        })
+    });
 }
 
 fn bench_populate_100000(c: &mut Criterion) {
@@ -52,11 +55,13 @@ fn bench_populate_100000(c: &mut Criterion) {
         *key = rng.gen();
     }
 
-    c.bench_function("bench_populate_100000",|b| b.iter(|| {
-        let mut filter = Xor8::<RandomState>::new();
-        filter.populate(&keys);
-        filter.build();
-    }));
+    c.bench_function("bench_populate_100000", |b| {
+        b.iter(|| {
+            let mut filter = Xor8::<RandomState>::new();
+            filter.populate(&keys);
+            filter.build();
+        })
+    });
 }
 
 fn bench_insert_100000(c: &mut Criterion) {
@@ -70,11 +75,13 @@ fn bench_insert_100000(c: &mut Criterion) {
         *key = rng.gen();
     }
 
-    c.bench_function("bench_insert_100000",|b| b.iter(|| {
-        let mut filter = Xor8::<RandomState>::new();
-        keys.iter().for_each(|key| filter.insert(key));
-        filter.build();
-    }));
+    c.bench_function("bench_insert_100000", |b| {
+        b.iter(|| {
+            let mut filter = Xor8::<RandomState>::new();
+            keys.iter().for_each(|key| filter.insert(key));
+            filter.build();
+        })
+    });
 }
 
 fn bench_contains_100000(c: &mut Criterion) {
@@ -96,10 +103,12 @@ fn bench_contains_100000(c: &mut Criterion) {
     };
 
     let mut n = 0;
-    c.bench_function("bench_contains_100000",|b| b.iter(|| {
-        filter.contains(keys[n % keys.len()]);
-        n += 1;
-    }));
+    c.bench_function("bench_contains_100000", |b| {
+        b.iter(|| {
+            filter.contains(keys[n % keys.len()]);
+            n += 1;
+        })
+    });
 }
 
 fn bench_contains_key_100000(c: &mut Criterion) {
@@ -121,14 +130,16 @@ fn bench_contains_key_100000(c: &mut Criterion) {
     };
 
     let mut n = 0;
-    c.bench_function("bench_contains_key_100000",|b| b.iter(|| {
-        filter.contains_key(keys[n % keys.len()]);
-        n += 1;
-    }));
+    c.bench_function("bench_contains_key_100000", |b| {
+        b.iter(|| {
+            filter.contains_key(keys[n % keys.len()]);
+            n += 1;
+        })
+    });
 }
 
 criterion_group!(
-    benches, 
+    benches,
     bench_populate_keys_100000,
     bench_build_keys_100000,
     bench_populate_100000,
@@ -138,5 +149,3 @@ criterion_group!(
 );
 
 criterion_main!(benches);
-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //! [original implementation](https://github.com/FastFilter/xorfilter)
 //! written in golang.
 
+use serde::{Deserialize, Serialize};
 use std::{
     collections::hash_map::RandomState,
     convert::TryInto,
@@ -68,6 +69,7 @@ struct KeyIndex {
 ///
 /// This implementation has a false positive rate of about 0.3%
 /// and a memory usage of less than 9 bits per entry for sizeable sets.
+#[derive(Serialize, Deserialize)]
 pub struct Xor8<H = RandomState>
 where
     H: BuildHasher,


### PR DESCRIPTION
I added serialization and deserialization using Serde's derive. I also ran `fmt` on it to make it look pretty (lmk if you want me to remove that).

I could expose the serialization and deserialization to end-users, but I feel like the decision to serialize to JSON, cbor, msgpack, etc. should be up to the user rather than a decision we impose.

Should fix #1.