### PR TITLE
Change: user iterator instead of slice as arg passed to populate_keys()

### DIFF
--- a/.github/workflows/simple-build-test.yml
+++ b/.github/workflows/simple-build-test.yml
@@ -1,6 +1,10 @@
 name: simple-build-test
 
-on: [push]
+on:
+  push:
+  pull_request:
+  schedule: [cron: "40 1 * * *"]
+
 
 jobs:
   build:

--- a/src/xor8.rs
+++ b/src/xor8.rs
@@ -205,12 +205,17 @@ where
     }
 
     /// Populate with pre-compute collection of 64-bit digests.
-    pub fn populate_keys(&mut self, digests: &[u64]) {
-        if let Some(x) = self.num_keys.as_mut() {
-            *x += digests.len()
+    pub fn populate_keys<'i, I: IntoIterator<Item = &'i u64>>(&mut self, digests: I) {
+        let mut n = 0;
+
+        let keys = self.keys.as_mut().unwrap();
+        for digest in digests.into_iter() {
+            n += 1;
+            keys.insert(*digest, ());
         }
-        for digest in digests.iter() {
-            self.keys.as_mut().unwrap().insert(*digest, ());
+
+        if let Some(x) = self.num_keys.as_mut() {
+            *x += n
         }
     }
 


### PR DESCRIPTION
Sometimes an application does not have all of the keys stored in a `Vec` but in some other iterable storage., using a `&[K]` as the source for building, the application has to rebuild a `Vec`, which is an unnecessary cost.

The keys for building can be an `impl Iterator<Item=&u64>` so that the application does not bother building another `Vec`.

Add another test that takes less time to quickly address issues when developing.