### PR TITLE
CI: disable the very slow debug mode test

### DIFF
--- a/.github/workflows/simple-build-test.yml
+++ b/.github/workflows/simple-build-test.yml
@@ -19,7 +19,9 @@ jobs:
           - "nightly"
         profile:
           - "--release"
-          - ""
+          # Disable debug mode test
+          # It's about 10 times slower with debug mode: ~ 10 minutes
+          # - ""
         cmd:
           - "build"
           - "test"


### PR DESCRIPTION
## Changelog

##### CI: disable the very slow debug mode test

- Fix: #21



- Build/Testing/CI